### PR TITLE
Fix code scanning alert no. 9: Missing regular expression anchor

### DIFF
--- a/get_auth_headers_exe/find_place_web_app.go
+++ b/get_auth_headers_exe/find_place_web_app.go
@@ -155,7 +155,7 @@ func extractXHeaders() error {
 
 func handleRequest(request playwright.Request) {
 	if !intercepted {
-		matched, _ := regexp.MatchString(`https://www\.booking\.com/dml/graphql.*`, request.URL())
+		matched, _ := regexp.MatchString(`^https://www\.booking\.com/dml/graphql.*$`, request.URL())
 		if matched {
 			headers := request.Headers()
 			envVars := make(map[string]string)


### PR DESCRIPTION
Fixes [https://github.com/sakan811/Find-the-Best-Place-to-Stay-with-Price-per-Review/security/code-scanning/9](https://github.com/sakan811/Find-the-Best-Place-to-Stay-with-Price-per-Review/security/code-scanning/9)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the URL from the beginning to the end. This will prevent any unintended matches and ensure that only the exact URL pattern is matched.

- Add the `^` anchor at the beginning of the regular expression to ensure it matches from the start of the string.
- Add the `$` anchor at the end of the regular expression to ensure it matches until the end of the string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
